### PR TITLE
Add power connection to allow network connections to efficiency detecting buildings.

### DIFF
--- a/Source/EfficiencyCheckerMod/Private/EfficiencyCheckerBuilding.cpp
+++ b/Source/EfficiencyCheckerMod/Private/EfficiencyCheckerBuilding.cpp
@@ -27,6 +27,11 @@
 // Sets default values
 AEfficiencyCheckerBuilding::AEfficiencyCheckerBuilding()
 {
+	//Add dummy power connector for Ficsit Networks cable compatability
+	class UFGPowerConnectionComponent* FGPowerConnection;
+	FGPowerConnection = CreateDefaultSubobject<UFGPowerConnectionComponent>(TEXT("FGPowerConnection"));
+	FGPowerConnection->SetupAttachment(RootComponent);
+	
 	PrimaryActorTick.bCanEverTick = true;
 	PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	PrimaryActorTick.bStartWithTickEnabled = false;

--- a/Source/EfficiencyCheckerMod/Private/EfficiencyCheckerBuilding.cpp
+++ b/Source/EfficiencyCheckerMod/Private/EfficiencyCheckerBuilding.cpp
@@ -17,6 +17,7 @@
 #include "Logic/EfficiencyCheckerLogic.h"
 #include "Util/EfficiencyCheckerOptimize.h"
 #include "Util/Logging.h"
+#include "FGPowerConnectionComponent.h"
 
 #include <map>
 


### PR DESCRIPTION
Hello,

I noticed that the Ficsit Networks compatibility appears to be broken due to not being able to connect network cables to the detectors, so I fixed it (clumsily, I may add; I'm kind of new to this, so improvements to this simple block are probably possible).

This PR adds the ability to connect network cables to the buildable detectors. Connection point is on the bottom, probably could be made better if moved. Also, allows the connection of a single power wire which does nothing if attached, which could be prevented by setting the max connections to 0 on an extension of the UFGPowerConnectionComponent, but I'm kind of new to this so I didn't mess with it too much.